### PR TITLE
Feature/29 authbug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "ncoder",
+  "name": "ncodr",
   "version": "0.9.1",
   "lockfileVersion": 1,
   "requires": true,
@@ -9401,6 +9401,12 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.2.0.tgz",
       "integrity": "sha512-Z72B4a0l0IQe5uWi9yzcqX/Ml6K9e1Hp03NmkjJnRG3gDsKTX7KvLFZsVUmCaz0eqeXLLK089mwTsP1P1W+DUQ==",
+      "dev": true
+    },
+    "sinon-express-mock": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/sinon-express-mock/-/sinon-express-mock-2.0.4.tgz",
+      "integrity": "sha512-5PLjXQmx3u/dwF+UthyFK+UxGKDcrLWZFXodorLI7ci/5Zcmm5iuYv2Pc6RbkIiMuM17mkm9O3L96uvubd08GQ==",
       "dev": true
     },
     "slash": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5034,9 +5034,9 @@
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
     },
     "jsonwebtoken": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.2.2.tgz",
-      "integrity": "sha512-rFFq7ow/JpPzwgaz4IyRL9cp7f4ptjW92eZgsQyqkysLBmDjSSBhnKfQESoq0GU+qJXK/CQ0o4shgwbUPiFCdw==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.3.0.tgz",
+      "integrity": "sha512-oge/hvlmeJCH+iIz1DwcO7vKPkNGJHhgkspk8OH3VKlw+mbi42WtD4ig1+VXRln765vxptAv+xT26Fd3cteqag==",
       "requires": {
         "jws": "3.1.5",
         "lodash.includes": "4.3.0",
@@ -5046,8 +5046,7 @@
         "lodash.isplainobject": "4.0.6",
         "lodash.isstring": "4.0.1",
         "lodash.once": "4.1.1",
-        "ms": "2.1.1",
-        "xtend": "4.0.1"
+        "ms": "2.1.1"
       },
       "dependencies": {
         "ms": {
@@ -5682,6 +5681,9 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "ncodr-ui": {
+      "version": "github:aztechian/ncodr-ui#e8973c6e779019d400604b0d3a851f12caa5b687"
+    },
     "ndjson": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/ndjson/-/ndjson-1.5.0.tgz",
@@ -5718,9 +5720,9 @@
       "dev": true
     },
     "nise": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.0.tgz",
-      "integrity": "sha512-vQ4J69BBu0CjNoTJICJzIEzmomn+KqLLAp6VSv5zU6Ea3HI01rg86yUuCmzNv+AhxpRvLiTufV+c72sIzF9Wiw==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.2.tgz",
+      "integrity": "sha512-BxH/DxoQYYdhKgVAfqVy4pzXRZELHOIewzoesxpjYvpU+7YOalQhGNPf7wAx8pLrTNPrHRDlLOkAl8UI0ZpXjw==",
       "dev": true,
       "requires": {
         "@sinonjs/formatio": "2.0.0",
@@ -5753,9 +5755,9 @@
       "integrity": "sha1-ICtIAhoMTL3i34DeFaF0Q8i0OYA="
     },
     "nock": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-9.3.0.tgz",
-      "integrity": "sha512-uJZKsOXdCqHkzUXD94SARpB8HgAVvALBBN0aD3RJO6vgBQDjy9u0uVhYzlApgfSnckfcfFh9XF/JV6FsJHz4Bg==",
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-9.3.3.tgz",
+      "integrity": "sha512-FBgnx25er2ly7KBr0Est5F0z5g+lnyr6a72vZI1KMi7nTL4ojU6XpFhlrfw6CXRdnT2FA5i8exHiT1uVNUM1qA==",
       "dev": true,
       "requires": {
         "chai": "4.1.2",
@@ -9370,16 +9372,16 @@
       "dev": true
     },
     "sinon": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-5.0.10.tgz",
-      "integrity": "sha512-+YT7Mjr8BpNndQqUUydO/daggF4yuOAnsVjo+5Ayx3mLLUqojfkXhDkho4HB5VgfnZYSdhxVDPbfJ2EBXFMSvA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-5.1.1.tgz",
+      "integrity": "sha512-h/3uHscbt5pQNxkf7Y/Lb9/OM44YNCicHakcq73ncbrIS8lXg+ZGOZbtuU+/km4YnyiCYfQQEwANaReJz7KDfw==",
       "dev": true,
       "requires": {
         "@sinonjs/formatio": "2.0.0",
         "diff": "3.5.0",
         "lodash.get": "4.4.2",
         "lolex": "2.7.0",
-        "nise": "1.4.0",
+        "nise": "1.4.2",
         "supports-color": "5.4.0",
         "type-detect": "4.0.8"
       },
@@ -9396,9 +9398,9 @@
       }
     },
     "sinon-chai": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.1.0.tgz",
-      "integrity": "sha512-gKcpH0GpDwEDWq6DXzdKf2PCvK4MgB2x6w1hSaNVQKnGF7vDY+uM7RK15pHqRuleypDKFpLUVDPTvlpyBVV1Mw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.2.0.tgz",
+      "integrity": "sha512-Z72B4a0l0IQe5uWi9yzcqX/Ml6K9e1Hp03NmkjJnRG3gDsKTX7KvLFZsVUmCaz0eqeXLLK089mwTsP1P1W+DUQ==",
       "dev": true
     },
     "slash": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ncoder",
+  "name": "ncodr",
   "version": "0.9.1",
   "description": "Encoding/Ripping Queue",
   "engines": [
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/aztechian/ncoder.git"
+    "url": "git+https://github.com/aztechian/ncodr.git"
   },
   "keywords": [
     "encode",
@@ -31,9 +31,9 @@
   "author": "Ian Martin <ian@imartin.net>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/aztechian/ncoder/issues"
+    "url": "https://github.com/aztechian/ncodr/issues"
   },
-  "homepage": "https://github.com/aztechian/ncoder#readme",
+  "homepage": "https://github.com/aztechian/ncodr#readme",
   "dependencies": {
     "atob": "^2.0.3",
     "babel-register": "^6.0",
@@ -75,6 +75,7 @@
     "nock": "^9.3.3",
     "nyc": "^12.0.2",
     "sinon": "^5.1.1",
-    "sinon-chai": "^3.2.0"
+    "sinon-chai": "^3.2.0",
+    "sinon-express-mock": "^2.0.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -48,9 +48,9 @@
     "got": "^8.3.0",
     "helmet": "^3.12.1",
     "js-yaml": "^3.12.0",
-    "jsonwebtoken": "^8.2.2",
+    "jsonwebtoken": "^8.3.0",
     "keyv": "^3.0.0",
-    "ncodr-ui": "github:aztechian/ncodr-ui#v1.2.5",
+    "ncodr-ui": "github:aztechian/ncodr-ui#v1.2.6",
     "parse-cache-control": "^1.0.1",
     "pino": "^4.17.3",
     "pino-clf": "^1.0.2",
@@ -72,9 +72,9 @@
     "jsdoc": "^3.5.5",
     "mocha": "^5.2.0",
     "mock-spawn": "*",
-    "nock": "^9.3.0",
+    "nock": "^9.3.3",
     "nyc": "^12.0.2",
-    "sinon": "^5.0.10",
-    "sinon-chai": "^3.1.0"
+    "sinon": "^5.1.1",
+    "sinon-chai": "^3.2.0"
   }
 }

--- a/server/common/jwtAuth.js
+++ b/server/common/jwtAuth.js
@@ -162,7 +162,7 @@ export class JwtAuth {
   }
 
   static checkAuthHeader(header) {
-    return header && header.match(/^(jwt|bearer) /i);
+    return !!header && /^(jwt|bearer) /i.test(header);
   }
 
   /**

--- a/server/common/jwtAuth.js
+++ b/server/common/jwtAuth.js
@@ -6,7 +6,6 @@ import jsonwebtoken from 'jsonwebtoken';
 import logger from './logger';
 import { core as config } from './conf';
 
-
 export class JwtAuth {
   constructor() {
     this.cache = new Keyv();
@@ -103,7 +102,7 @@ export class JwtAuth {
     // verify will throw exception in case of failure, goes down to .catch
     if (config.has('auth.googleDomain')) {
       const domain = config.get('auth.googleDomain');
-      this.checkDomain(domain, payload);
+      JwtAuth.checkDomain(domain, payload);
     }
     return payload;
   }
@@ -118,7 +117,8 @@ export class JwtAuth {
    * @param  {String} payload.hd The home domain setting from Google's JWT implementation.
    * @return {Boolean}      Boolean indicating whether the checks pass
    */
-  checkDomain(domain, payload) {
+  static checkDomain(domain, payload) {
+    logger.debug(`Validating domain for request. Need "${domain}", got "${payload.hd}"`);
     if (domain && !payload.hd) {
       logger.warn(`Domain verification required for ${domain}, but user ${payload.sub} has no domain given.`);
       throw new Error('User has no google domain');
@@ -138,7 +138,7 @@ export class JwtAuth {
    * @return {Object}  An internal representation of the JWT for further processing by this class,
    *  contains the raw headers and payload as well as parsed headers and payloads.
    */
-  extractJwt(authHeader) {
+  static extractJwt(authHeader) {
     const [, token] = authHeader.split(' ');
     if (!token) {
       logger.warn('Invalid Authorization header format');
@@ -161,8 +161,21 @@ export class JwtAuth {
     };
   }
 
-  checkAuthHeader(header) {
+  static checkAuthHeader(header) {
     return header && header.match(/^(jwt|bearer) /i);
+  }
+
+  /**
+   * Determines if this request is reasonably valid for an event stream (Server-Sent Events)
+   * @param  {object}  req The Express Request object
+   * @return {Boolean}     Boolean to indicate if the request is for an Event
+   */
+  static isEventRequest(req) {
+    if (/text\/event-stream/.test(req.get('Accept')) &&
+      /\/events$/.test(req.path)) {
+      return true;
+    }
+    return false;
   }
 
   /**
@@ -176,7 +189,7 @@ export class JwtAuth {
    * is completed.
    */
   auth(authHeader) {
-    const jwt = this.extractJwt(authHeader);
+    const jwt = JwtAuth.extractJwt(authHeader);
     // becuase this will be taken into the promise scope, we must explicitly bind this to the
     // class object so we can reference it later.
     // no free lunches... who'd have guessed!
@@ -205,10 +218,10 @@ export default function () {
     // for those requests to legitimately authenticate - short of reimplementing EventSource as
     // an XHR request instead. So, we'll just let those requests through. Don't put too much
     // sensitive info in SSE events...
-    if (req.accepts('text/event-stream')) return next();
+    if (JwtAuth.isEventRequest(req)) return next();
 
     const authHeader = req.header('Authorization');
-    if (!jwtAuth.checkAuthHeader(authHeader)) return Promise.resolve(res.status(403).send());
+    if (!JwtAuth.checkAuthHeader(authHeader)) return Promise.resolve(res.status(403).send());
 
     return jwtAuth.auth(authHeader)
       .then(payload => {


### PR DESCRIPTION
Fixes #29 

It turns out that a regular browser will send requests with an `Accept` header of something like:

> text/html, \*/\*

Which matched the express functions logic for .accepts('text/event-stream'). (The `*/*` part makes anything match). Then, auth just wouldn't be done at all 😱 

This is now fixed.